### PR TITLE
Изменения алгоритма поиска строки

### DIFF
--- a/irbis/core.py
+++ b/irbis/core.py
@@ -833,17 +833,20 @@ class ServerResponse:
         :return: Считанная строка.
         """
         result = bytearray()
+        
         while True:
-            if not self._memory:
-                break
-            char = self._memory.pop(0)
-            if char == 0x0D:
-                if not self._memory:
+            first = self._memory.find(0x0D)
+            if first == -1:
+                result = self._memory
+                self._memory = bytearray()
+                return result
+            result = self._memory[:first]
+            if first + 1 != len(self._memory):
+                if self._memory[first + 1] == 0x0A:
                     break
-                char = self._memory.pop(0)
-                if char == 0x0A:
-                    break
-            result.append(char)
+        else:
+            result = self._memory
+        self._memory = self._memory[first + 2:]
         return result
 
     def utf(self) -> str:
@@ -1226,7 +1229,6 @@ class RecordField:
 class MarcRecord:
     """
     MARC record with MFN, status, version and fields.
-    """
 
     __slots__ = 'database', 'mfn', 'version', 'status', 'fields'
 


### PR DESCRIPTION
Некоторые записи в ИРБИС имеют длину не закодированной строки в миллион символов и больше. Предыдущий способ поиска был не оптимальным и на некоторые записи обрабатывались слишком долго (До оптимизации - после 10 минут ожидания процесс был принудительно завершен https://pastebin.com/ACU7J0uy), поэтому пришлось изменить способ разделения запроса на строки (После оптимизации https://pastebin.com/Y5Rr8690). Я не претендую на 100% правильность данного способа, но на проведенных мной тестах ошибок найдено не было.