### PR TITLE
Fix return for first

### DIFF
--- a/irbis/record.py
+++ b/irbis/record.py
@@ -600,7 +600,7 @@ class MarcRecord:
 
         for field in self.fields:
             if field.tag == tag:
-                return field
+                return field.value
         return None
 
     def have_field(self, tag: int) -> bool:


### PR DESCRIPTION
Функция fm возвращает значение SubField, так же как и fma. Для first ожидаемым поведением является возврат SubField.value, а не самого объекта. Предлагаю сделать единообразно. Как по мне лучше что бы всегда возвращался сам объект, но возможно это избыточно.