### PR TITLE
Fix `long_description_content_type` in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setuptools.setup(
     description="Framework for client development for popular Prussian library computer system IRBIS64",
     keywords='IRBIS64',
     long_description=long_description,
-    long_description_content_type="text/markdown",
+    long_description_content_type="text/x-rst",
     url="https://github.com/amironov73/PythonIrbis",
     packages=setuptools.find_packages(),
     classifiers=[


### PR DESCRIPTION
В описании последнего релиза на PyPI ( https://pypi.org/project/irbis ) некорректно отрисовалась разметка.

Наиболее вероятная причина -- указанный MIME-тип для разметки markdown в `setup.py`:
```
long_description_content_type="text/markdown"
```
Предлагаю изменить на MIME-тип для разметки reStructuredText:
```
long_description_content_type="text/x-rst"
```